### PR TITLE
Add URDF parsing for continuous/effort limit

### DIFF
--- a/fetch_gazebo/config/default_controllers.yaml
+++ b/fetch_gazebo/config/default_controllers.yaml
@@ -80,7 +80,6 @@ gazebo:
       d: 0.0
       i: 0.5
       i_clamp: 6.0
-    effort_limit: 8.85
   r_wheel_joint:
     position:
       p: 0.0
@@ -92,7 +91,6 @@ gazebo:
       d: 0.0
       i: 0.5
       i_clamp: 6.0
-    effort_limit: 8.85
   torso_lift_joint:
     position:
       p: 150000.0
@@ -170,8 +168,6 @@ gazebo:
       d: 0.0
       i: 0.0
       i_clamp: 0.0
-    continuous: true
-    effort_limit: 76.94
   elbow_flex_joint:
     position:
       p: 500.0
@@ -194,8 +190,6 @@ gazebo:
       d: 0.0
       i: 0.0
       i_clamp: 0.0
-    continuous: true
-    effort_limit: 29.35
   wrist_flex_joint:
     position:
       p: 100.0
@@ -218,8 +212,6 @@ gazebo:
       d: 0.0
       i: 0.0
       i_clamp: 0.0
-    continuous: true
-    effort_limit: 7.36
   l_gripper_finger_joint:
     position:
       p: 5000.0

--- a/fetch_gazebo/include/fetch_gazebo/joint_handle.h
+++ b/fetch_gazebo/include/fetch_gazebo/joint_handle.h
@@ -59,7 +59,9 @@ class JointHandle : public robot_controllers::JointHandle
   };
 
 public:
-  JointHandle(physics::JointPtr& joint) :
+  JointHandle(physics::JointPtr& joint,
+              const float effort_limit,
+              const bool continuous) :
     joint_(joint),
     mode_(MODE_DISABLED)
   {
@@ -69,11 +71,9 @@ public:
     position_pid_.init(ros::NodeHandle(nh, getName() + "/position"));
     velocity_pid_.init(ros::NodeHandle(nh, getName() + "/velocity"));
 
-    // Load optional effort_limit as a workaround to gzsdf limitation
-    nh.param(getName() + "/effort_limit", effort_limit_, -1.0);
-
-    // Pull continuous from parameters
-    nh.param(getName() + "/continuous", continuous_, false);
+    // Set effort limit and continuous state
+    effort_limit_ = effort_limit;
+    continuous_ = continuous;
   }
   virtual ~JointHandle()
   {


### PR DESCRIPTION
This makes the plugin for gazebo use parameters specified in the robot description instead of a YAML file.
