### PR TITLE
Fixed number of samples for the laser scanner

### DIFF
--- a/fetch_gazebo/robots/fetch.gazebo.xacro
+++ b/fetch_gazebo/robots/fetch.gazebo.xacro
@@ -73,7 +73,7 @@
       <ray>
         <scan>
           <horizontal>
-            <samples>661</samples>
+            <samples>662</samples>
             <resolution>1</resolution>
             <min_angle>-1.91986</min_angle>
             <max_angle>1.91986</max_angle>

--- a/fetch_gazebo/robots/freight.gazebo.xacro
+++ b/fetch_gazebo/robots/freight.gazebo.xacro
@@ -47,7 +47,7 @@
       <ray>
         <scan>
           <horizontal>
-            <samples>661</samples>
+            <samples>662</samples>
             <resolution>1</resolution>
             <min_angle>-1.91986</min_angle>
             <max_angle>1.91986</max_angle>


### PR DESCRIPTION
Real laser scan has 662 samples, not 661 samples
