### PR TITLE
Robot launch files publish base_scan_raw

### DIFF
--- a/fetch_gazebo/launch/include/fetch.launch.xml
+++ b/fetch_gazebo/launch/include/fetch.launch.xml
@@ -24,6 +24,11 @@
   <!-- Head Camera Pipeline -->
   <include file="$(find fetch_gazebo)/launch/include/head_camera.launch.xml" />
 
+  <!-- Publish base_scan_raw if anything subscribes to it -->
+  <node name="publish_base_scan_raw" pkg="topic_tools" type="relay" args="base_scan base_scan_raw" >
+    <param name="lazy" type="bool" value="True"/>
+  </node>
+
   <!-- Start a mux between application and teleop -->
   <node pkg="topic_tools" type="mux" name="cmd_vel_mux" respawn="true" args="base_controller/command /cmd_vel /teleop/cmd_vel">
     <remap from="mux" to="cmd_vel_mux" />

--- a/fetch_gazebo/launch/include/freight.launch.xml
+++ b/fetch_gazebo/launch/include/freight.launch.xml
@@ -20,6 +20,11 @@
   <param name="robot/serial" value="XWVUTSRQPONMLKJIHGFEDCBA" />
   <param name="robot/version" value="0.0.1" />
 
+  <!-- Publish base_scan_raw if anything subscribes to it -->
+  <node name="publish_base_scan_raw" pkg="topic_tools" type="relay" args="base_scan base_scan_raw" >
+    <param name="lazy" type="bool" value="True"/>
+  </node>
+
   <!-- Start a mux between application and teleop -->
   <node pkg="topic_tools" type="mux" name="cmd_vel_mux" respawn="true" args="base_controller/command /cmd_vel /teleop/cmd_vel">
     <remap from="mux" to="cmd_vel_mux" />


### PR DESCRIPTION
Real robots get raw scan data from the laser scanner via the topic base_scan_raw. They then do some post processing before publishing base_scan. Presently, simulation only has a topic base_scan.  Some users may write nodes that subscribe to base_scan_raw and expect it to be present.

This request adds a relay to publish base_scan_raw. Since base_scan_raw is not often used, the relay is set to be lazy. This will publish base_scan_raw when something subscribes to it, but otherwise has a negligible performance impact.
