### PR TITLE
Add a sample to play with Object Recognition Kitchen(ORK)

### DIFF
--- a/fetch_gazebo_demo/config/detection.fetch.ork
+++ b/fetch_gazebo_demo/config/detection.fetch.ork
@@ -1,0 +1,67 @@
+source1:
+  type: RosKinect
+  module: 'object_recognition_ros.io'
+  parameters:
+    rgb_frame_id: '/head_camera_depth_optical_frame'
+    rgb_image_topic: '/head_camera/rgb/image_raw'
+    rgb_camera_info: '/head_camera/rgb/camera_info'
+    depth_image_topic: '/head_camera/depth_registered/image_raw'
+    depth_camera_info: '/head_camera/depth_registered/camera_info'
+    #
+    #crop_enabled: True
+    #x_min: -0.4
+    #x_max: 0.4
+    #y_min: -1.0
+    #y_max: 0.2
+    #z_min: 0.3
+    #z_max: 1.5
+
+sink1:
+  type: TablePublisher
+  module: 'object_recognition_tabletop'
+  inputs: [source1]
+
+sink2:
+  type: Publisher
+  module: 'object_recognition_ros.io'
+  inputs: [source1]
+
+# Recognize planes
+pipeline1:
+  type: TabletopTableDetector
+  module: 'object_recognition_tabletop'
+  inputs: [source1]
+  outputs: [sink1]
+  parameters:
+    table_detector:
+        #min_table_size: 4000
+        #plane_threshold: 0.01
+        min_table_size: 500
+        plane_threshold: 0.01
+    #clusterer:
+    #    table_z_filter_max: 0.35
+    #    table_z_filter_min: 0.025
+
+# Recognize objects which you have already registered on your database.
+pipeline2:
+  type: LinemodDetector
+  module: 'object_recognition_linemod'
+  inputs: [source1]
+  outputs: [sink2]
+  parameters:
+    use_rgb: 1
+    use_depth: 1
+    verbose: 1
+    visualize: 1
+    threshold: 91.6 #82.9 #91.6 
+    th_obj_dist: 0.1
+    icp_dist_min: 0.05 #0.06
+    px_match_min: 0.25 #0.5
+    depth_frame_id: 'head_camera_depth_optical_frame' #CameraDepth_frame
+    # The list of object_ids to analyze
+    object_ids: 'all'
+    #object_ids: ['24e0dc763c918714368b41b1c3000c23']
+    db:
+      type: 'CouchDB'
+      root: 'http://localhost:5984'
+      collection: 'object_recognition'

--- a/fetch_gazebo_demo/config/recognize.rviz
+++ b/fetch_gazebo_demo/config/recognize.rviz
@@ -1,0 +1,268 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /OrkObject1
+        - /OrkTable1
+      Splitter Ratio: 0.5
+    Tree Height: 565
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bellows_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bellows_link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        elbow_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        estop_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        forearm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        gripper_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_camera_depth_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_depth_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_rgb_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_rgb_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_tilt_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        laser_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        shoulder_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        shoulder_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        torso_fixed_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        torso_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        upperarm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wrist_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wrist_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: object_recognition_ros/OrkObject
+      Confidence: true
+      Enabled: true
+      ID: false
+      Name: OrkObject
+      Topic: /recognized_object_array
+      Value: true
+    - Bounding Box: false
+      Class: object_recognition_ros/OrkTable
+      Color: 0; 255; 255
+      Enabled: true
+      Hull: true
+      Name: OrkTable
+      Top: true
+      Topic: /table_array
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 4.44629
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 1.28276
+        Y: -0.184853
+        Z: 0.772473
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.295398
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 2.0504
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000013c000002c4fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000002c4000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000002c4000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002f600fffffffb0000000800540069006d006501000000000000045000000000000000000000036e000002c400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1200
+  X: 55
+  Y: 50

--- a/fetch_gazebo_demo/launch/recognize_demo.launch
+++ b/fetch_gazebo_demo/launch/recognize_demo.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <!-- Run object recognition detector -->
+  <arg name="config_file_objects" default="$(find fetch_gazebo_demo)/config/detection.fetch.ork"/>
+  <node pkg="object_recognition_core" name="recognize_objects" type="detection" args="-c $(arg config_file_objects)">
+  </node>
+
+  <!-- Run Rviz and load the default config to see the state of the move_group node -->
+  <arg name="rviz_cfg" default="-d $(find fetch_gazebo_demo)/config/recognize.rviz" />
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"
+	args="$(arg rviz_cfg)" output="screen" />
+
+</launch>

--- a/fetch_gazebo_demo/package.xml
+++ b/fetch_gazebo_demo/package.xml
@@ -18,4 +18,5 @@
   <run_depend>moveit_python</run_depend>
   <run_depend>simple_grasping</run_depend>
   <run_depend>teleop_twist_keyboard</run_depend>
+  <run_depend>object_recognition_core</run_depend>
 </package>


### PR DESCRIPTION
This PR adds a sample to use [ORK](http://wg-perception.github.io/object_recognition_core/index.html#index) with fetch.
This sample is confirmed with gazebo and actual robot.

In gazebo,
`roslaunch fetch_gazebo pickplace_playground.launch`
[Another terminal]
`roslaunch fetch_gazebo_demo recognize_demo.launch`

Enjoy!
