### PR TITLE
[fetch_simulation] new meta-package (#52)

### DIFF
--- a/fetch_simulation/CMakeList.txt
+++ b/fetch_simulation/CMakeList.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(fetch_simulation)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/fetch_simulation/package.xml
+++ b/fetch_simulation/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>fetch_simulation</name>
+  <version>0.8.0</version>
+  <description>Fetch Simulation, packages for working with Fetch and Freight in Gazebo</description>
+  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+
+  <license>BSD</license>
+  <url type="website">https://docs.fetchrobotics.com/gazebo.html</url>
+  <url type="repository">https://github.com/fetchrobotics/fetch_gazebo</url>
+  <url type="bugtracker">https://github.com/fetchrobotics/fetch_gazebo/issues</url>
+  <url type="wiki">https://wiki.ros.org/fetch_simulation</url>
+
+  <author email="amoriarty@fetchrobotics.com">Alex Moriarty</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>fetch_gazebo</exec_depend>
+  <exec_depend>fetch_gazebo_demo</exec_depend>
+  <exec_depend>fetchit_challenge</exec_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
A meta-package makes installing things easier and they're used with
wiki.ros.org and index.ros.org to automatically group and link things.

This is a back-port of #52 related to #53 