### PR TITLE
cmake_minimum_required(VERSION 3.7.2) & C++14

### DIFF
--- a/fetch_gazebo/CMakeLists.txt
+++ b/fetch_gazebo/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7.2)
 project(fetch_gazebo)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 
 find_package(Boost REQUIRED)
 find_package(gazebo REQUIRED)

--- a/fetch_gazebo_demo/CMakeLists.txt
+++ b/fetch_gazebo_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7.2)
 project(fetch_gazebo_demo)
 
 find_package(catkin)

--- a/fetch_simulation/CMakeLists.txt
+++ b/fetch_simulation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7.2)
 project(fetch_simulation)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/fetchit_challenge/CMakeLists.txt
+++ b/fetchit_challenge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7.2)
 project(fetchit_challenge)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
- Bump the minimum CMake version, to fix a CMake warning.
- Remove explicit CMAKE_CXX_FLAGS c++0x because the default is now
C++14

I recently enabled melodic tests on build.ros.org and #63 had a CMake warning.
http://build.ros.org/view/Idev/job/Mdev__fetch_gazebo__ubuntu_bionic_amd64/ [![Build Status](http://build.ros.org/view/Idev/job/Mdev__fetch_gazebo__ubuntu_bionic_amd64/badge/icon)](http://build.ros.org/view/Idev/job/Mdev__fetch_gazebo__ubuntu_bionic_amd64/)