### PR TITLE
Cleanup dependencies

### DIFF
--- a/fetch_gazebo/package.xml
+++ b/fetch_gazebo/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>libgazebo9-dev</build_depend>
+  <build_depend>gazebo_dev</build_depend>
 
   <depend>control_toolbox</depend>
   <depend>boost</depend>

--- a/fetchit_challenge/CMakeLists.txt
+++ b/fetchit_challenge/CMakeLists.txt
@@ -1,36 +1,13 @@
 cmake_minimum_required(VERSION 3.7.2)
 project(fetchit_challenge)
 
-find_package(catkin REQUIRED COMPONENTS
-  controller_manager
-  fetch_gazebo
-  gazebo_ros
-  robot_state_publisher
-  rospy
-)
-
-###################################
-## catkin specific configuration ##
-###################################
+find_package(catkin REQUIRED)
 catkin_package()
-
-###########
-## Build ##
-###########
-
-include_directories(
-  ${catkin_INCLUDE_DIRS}
-)
 
 #############
 ## Install ##
 #############
 
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
 install(
   PROGRAMS
     scripts/spawn_assembly_delayed.sh

--- a/fetchit_challenge/package.xml
+++ b/fetchit_challenge/package.xml
@@ -19,22 +19,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>gazebo_ros</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>robot_state_publisher</build_depend>
-  <build_depend>controller_manager</build_depend>
-  <build_depend>fetch_gazebo</build_depend>
-  
-  <build_export_depend>rospy</build_export_depend>
-  
   <exec_depend>effort_controllers</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>fetch_gazebo</exec_depend>
-
-
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
This package is currently failing on the build farm for all debian
Stretch binary builds (amd64 and arm64)

When it tries to install the dependencies there are many
Gazebo7/Gazebo9, and sdformat4/sdformat6 conflicts.

http://build.ros.org/job/Mbin_ds_dS64__fetchit_challenge__debian_stretch_amd64__binary/

Possibly related to ros/rosdistro#19843