### PR TITLE
catkin_make only supports cmake 2.8.3 for meta-pkg

### DIFF
--- a/fetch_simulation/CMakeLists.txt
+++ b/fetch_simulation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 2.8.3)
 project(fetch_simulation)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
This fixes #69 