### PR TITLE
Missing utility cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fetch Gazebo
+# Fetch Gazebo x
 
 This repository contains the Gazebo simulation for Fetch Robotics Fetch and
 Freight Research Edition Robots.

--- a/fetchit_challenge/launch/assembly_largegear_spawn.launch
+++ b/fetchit_challenge/launch/assembly_largegear_spawn.launch
@@ -2,14 +2,14 @@
 
 <launch>
 
-    <arg name="robot_name" default="gearbox_largegear" />
+    <arg name="robot_name" default="gearbox_largegear_grey" />
     <arg name="x" default="3.680528" />
     <arg name="y" default="-5.126981" />
     <arg name="z" default="0.8" />
     <arg name="roll" default="0"/>
     <arg name="pitch" default="0"/>
     <arg name="yaw" default="0.0" />
-    <arg name="sdf_robot_file" default="$(find fetchit_challenge)/models/gearbox_largegear/model.sdf" />
+    <arg name="sdf_robot_file" default="$(find fetchit_challenge)/models/gearbox_largegear_grey/model.sdf" />
 
 
     <node name="$(arg robot_name)_spawn_urdf" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"

--- a/fetchit_challenge/launch/assembly_smallgear_spawn.launch
+++ b/fetchit_challenge/launch/assembly_smallgear_spawn.launch
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
 
-    <arg name="robot_name" default="gearbox_smallgear" />
+    <arg name="robot_name" default="gearbox_smallgear_grey" />
     <arg name="x" default="3.533216" />
     <arg name="y" default="-5.091161" />
     <arg name="z" default="0.8" />
     <arg name="roll" default="0"/>
     <arg name="pitch" default="0"/>
     <arg name="yaw" default="0.0" />
-    <arg name="sdf_robot_file" default="$(find fetchit_challenge)/models/gearbox_smallgear/model.sdf" />
+    <arg name="sdf_robot_file" default="$(find fetchit_challenge)/models/gearbox_smallgear_grey/model.sdf" />
 
 
     <node name="$(arg robot_name)_spawn_urdf" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"

--- a/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019.world
+++ b/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019.world
@@ -40,8 +40,22 @@
     <include>
       <uri>model://caddy_green</uri>
       <name>caddy_green1</name>
-      <pose>0.0 -1.20441 0.826729 0 0 0</pose>
+      <pose>0.168355 -1.20441 0.826729 0 0 0</pose>
     </include>
+
+    <include>
+      <uri>model://caddy_red</uri>
+      <name>caddy_red1</name>
+      <pose>-0.113059 -1.20441 0.826729 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>model://caddy_yellow</uri>
+      <name>caddy_yellow1</name>
+      <pose>-0.414898 -1.20441 0.826729 0 0 0</pose>
+    </include>
+
+
 
 
     <include>

--- a/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019.world
+++ b/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019.world
@@ -2,7 +2,6 @@
 <sdf version="1.4">
   <world name="default">
 
-
     <include>
       <uri>model://ground_plane</uri>
       <pose>0 0 -0.005 0 0 0</pose>
@@ -38,10 +37,9 @@
       <pose>0.815 1.28179 0.0 0 0 0</pose>
     </include>
 
-
     <include>
-      <uri>model://romanoff_small_utility_caddy</uri>
-      <name>romanoff_small_utility_caddy1</name>
+      <uri>model://caddy_green</uri>
+      <name>caddy_green1</name>
       <pose>0.0 -1.20441 0.826729 0 0 0</pose>
     </include>
 
@@ -53,14 +51,14 @@
     </include>
 
     <include>
-      <uri>model://gearbox_bolt</uri>
-      <name>gearbox_bolt1</name>
+      <uri>model://gearbox_bolt_grey</uri>
+      <name>gearbox_bolt_grey1</name>
       <pose>1.19481 -0.727808 0.802789 0 0 0</pose>
     </include>
 
     <include>
-      <uri>model://gearbox_bolt</uri>
-      <name>gearbox_bolt2</name>
+      <uri>model://gearbox_bolt_grey</uri>
+      <name>gearbox_bolt_grey2</name>
       <pose>1.11789 -0.669909 0.802789 0 0 0</pose>
     </include>
 
@@ -72,14 +70,14 @@
     </include>
 
     <include>
-      <uri>model://gearbox_bottom</uri>
-      <name>gearbox_bottom1</name>
+      <uri>model://gearbox_bottom_grey</uri>
+      <name>gearbox_bottom_grey1</name>
       <pose>-0.319115 1.21719 0.864438 0 0 1.57</pose>
     </include>
 
     <include>
-      <uri>model://gearbox_top</uri>
-      <name>gearbox_top1</name>
+      <uri>model://gearbox_top_grey</uri>
+      <name>gearbox_top_grey1</name>
       <pose>-0.323154 1.15124 0.826531 0 0 0</pose>
     </include>
 

--- a/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019_highlights.world
+++ b/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019_highlights.world
@@ -40,7 +40,19 @@
     <include>
       <uri>model://caddy_green</uri>
       <name>caddy_green1</name>
-      <pose>0.0 -1.20441 0.826729 0 0 0</pose>
+      <pose>0.168355 -1.20441 0.826729 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>model://caddy_red</uri>
+      <name>caddy_red1</name>
+      <pose>-0.113059 -1.20441 0.826729 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>model://caddy_yellow</uri>
+      <name>caddy_yellow1</name>
+      <pose>-0.414898 -1.20441 0.826729 0 0 0</pose>
     </include>
 
 

--- a/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019_highlights.world
+++ b/fetchit_challenge/worlds/fetchit_challenge_arena_montreal2019_highlights.world
@@ -2,7 +2,6 @@
 <sdf version="1.4">
   <world name="default">
 
-
     <include>
       <uri>model://ground_plane</uri>
       <pose>0 0 -0.005 0 0 0</pose>
@@ -39,8 +38,8 @@
     </include>
 
     <include>
-      <uri>model://romanoff_small_utility_caddy</uri>
-      <name>romanoff_small_utility_caddy1</name>
+      <uri>model://caddy_green</uri>
+      <name>caddy_green1</name>
       <pose>0.0 -1.20441 0.826729 0 0 0</pose>
     </include>
 
@@ -52,14 +51,14 @@
     </include>
 
     <include>
-      <uri>model://gearbox_bolt</uri>
-      <name>gearbox_bolt1</name>
+      <uri>model://gearbox_bolt_grey</uri>
+      <name>gearbox_bolt_grey1</name>
       <pose>1.19481 -0.727808 0.802789 0 0 0</pose>
     </include>
 
     <include>
-      <uri>model://gearbox_bolt</uri>
-      <name>gearbox_bolt2</name>
+      <uri>model://gearbox_bolt_grey</uri>
+      <name>gearbox_bolt_grey2</name>
       <pose>1.11789 -0.669909 0.802789 0 0 0</pose>
     </include>
 
@@ -71,14 +70,14 @@
     </include>
 
     <include>
-      <uri>model://gearbox_bottom</uri>
-      <name>gearbox_bottom1</name>
+      <uri>model://gearbox_bottom_grey</uri>
+      <name>gearbox_bottom_grey1</name>
       <pose>-0.319115 1.21719 0.864438 0 0 1.57</pose>
     </include>
 
     <include>
-      <uri>model://gearbox_top</uri>
-      <name>gearbox_top1</name>
+      <uri>model://gearbox_top_grey</uri>
+      <name>gearbox_top_grey1</name>
       <pose>-0.323154 1.15124 0.826531 0 0 0</pose>
     </include>
 


### PR DESCRIPTION
This is a fix to the issue https://github.com/fetchrobotics/fetch_gazebo/issues/83.
I've added the new cart color model. Remember that now you have at your disposal loads of colors of carts to make tests.

I've also updated the colors of the assembly in the montreal2019 worlds so that they are more in line with reality.