### PR TITLE
Update Buildfarm Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Freight Research Edition Robots.
 
 Please note the _branch_: the default branch in GitHub is **gazebo9**.
 1. **gazebo9** should be used with **ROS Melodic** and **Ubuntu 18.04**
-2. **gazebo7** should be used with **ROS Kinetic** and **Ubuntu 16.04**
-3. **gazebo2** should be used with **ROS Indigo** and **Ubuntu 14.04**
+2. **gazebo7** should be used with **ROS Kinetic** and **Ubuntu 16.04** (not supported on hardware)
+3. **gazebo2** should be used with **ROS Indigo** and **Ubuntu 14.04** (EOL)
 
 ## Tutorial & Documentation
 
@@ -19,17 +19,17 @@ http://docs.fetchrobotics.com/gazebo.html#launch-it-on-rosds
 
 ## ROS Buildfarm Release
  
-Fetch Gazebo Package | Indigo Source | Indigo Debian | Kinetic Source | Kinetic Debian | Melodic Source | Melodic Debian
--------------------- | ------------- | ------------- | -------------- | -------------- | -------------- | --------------
-fetch_gazebo | [![Build Status](http://build.ros.org/buildStatus/icon?job=Isrc_uT__fetch_gazebo__ubuntu_trusty__source)](http://build.ros.org/job/Isrc_uT__fetch_gazebo__ubuntu_trusty__source/) | [![Build Status](http://build.ros.org/buildStatus/icon?job=Ibin_uT64__fetch_gazebo__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__fetch_gazebo__ubuntu_trusty_amd64__binary/) | | | | |
-fetch_gazebo_demo | [![Build Status](http://build.ros.org/buildStatus/icon?job=Isrc_uT__fetch_gazebo_demo__ubuntu_trusty__source)](http://build.ros.org/job/Isrc_uT__fetch_gazebo_demo__ubuntu_trusty__source/) | [![Build Status](http://build.ros.org/buildStatus/icon?job=Ibin_uT64__fetch_gazebo_demo__ubuntu_trusty_amd64__binary)](http://build.ros.org/job/Ibin_uT64__fetch_gazebo_demo__ubuntu_trusty_amd64__binary/) | | | | |
+Fetch Gazebo Package | Kinetic Source | Kinetic Debian | Melodic Source | Melodic Debian
+-------------------- | -------------- | -------------- | -------------- | --------------
+fetch_gazebo | [![Build Status](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__fetch_gazebo__ubuntu_xenial__source)](http://build.ros.org/job/Ksrc_uX__fetch_gazebo__ubuntu_xenial__source/) | [![Build Status](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__fetch_gazebo__ubuntu_xenial_amd64__binary)](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__fetch_gazebo__ubuntu_xenial_amd64__binary/) | [![Build Status](http://build.ros.org/buildStatus/icon?job=Msrc_uB__fetch_gazebo__ubuntu_bionic__source)](http://build.ros.org/view/Mbin_uB64/job/Msrc_uB__fetch_gazebo__ubuntu_bionic__source/) | [![Build Status](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__fetch_gazebo__ubuntu_bionic_amd64__binary)](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__fetch_gazebo__ubuntu_bionic_amd64__binary/) |
+fetch_gazebo_demo | [![Build Status](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__fetch_gazebo_demo__ubuntu_xenial__source)](http://build.ros.org/job/Ksrc_uX__fetch_gazebo_demo__ubuntu_xenial__source/) | [![Build Status](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__fetch_gazebo_demo__ubuntu_xenial_amd64__binary)](http://build.ros.org/job/Kbin_uX64__fetch_gazebo_demo__ubuntu_xenial_amd64__binary/) | | | | |
 fetchit_challenge | | | | | | |
 
 ## ROS Buildfarm Devel
 
-Fetch Gazebo Package | Indigo Devel | Kinetic Devel | Melodic Devel
--------------------- | ------------ | ------------- | -------------
-fetch_gazebo | [![Build Status](http://build.ros.org/buildStatus/icon?job=Idev__fetch_gazebo__ubuntu_trusty_amd64)](http://build.ros.org/view/Idev/job/Idev__fetch_gazebo__ubuntu_trusty_amd64/) | | |
+Fetch Gazebo Package | Melodic Devel
+-------------------- | -------------
+fetch_gazebo | [![Build Status](http://build.ros.org/buildStatus/icon?job=Mdev__fetch_gazebo__ubuntu_bionic_amd64)](http://build.ros.org/view/Mdev/job/Mdev__fetch_gazebo__ubuntu_bionic_amd64/)
 fetch_gazebo_demo | | | |
 fetchit_challenge | | | |
 


### PR DESCRIPTION
Indigo has been EOL and turned off, resulting in grey "Build | Not Run"
This only adds some of the badges.

@erelson - The grey badges bugged me, but didn't bug me enough to fill out all of them.

Happy Holidays