### PR TITLE
Run demo.launch on melodic

### DIFF
--- a/fetch_gazebo_demo/launch/demo.launch
+++ b/fetch_gazebo_demo/launch/demo.launch
@@ -16,4 +16,15 @@
   <!-- Drive to the table, pick stuff up -->
   <node name="demo" pkg="fetch_gazebo_demo" type="demo.py" output="screen" />
 
+  <!-- set rosparams to increase demo success rate -->
+  <rosparam>
+    <!-- Set inflation radius smaller inflation than default for fetch to come through narrow door -->
+    /move_base/local_costmap/inflater/inflation_radius: 0.3
+    /move_base/global_costmap/inflater/inflation_radius: 0.3
+    <!-- Set fetch's amcl pose at the origin of the map at the start of this demo, even if rosmaster was not killed and previous pose is saved -->
+    /amcl/initial_pose_x: 0.0
+    /amcl/initial_pose_y: 0.0
+    /amcl/initial_pose_a: 0.0
+  </rosparam>
+
 </launch>

--- a/fetch_gazebo_demo/scripts/demo.py
+++ b/fetch_gazebo_demo/scripts/demo.py
@@ -149,7 +149,7 @@ class GraspingClient(object):
             self.scene.addSolidPrimitive(obj.object.name,
                                          obj.object.primitives[0],
                                          obj.object.primitive_poses[0],
-                                         use_service=True)
+                                         use_service=False)
 
         for obj in find_result.support_surfaces:
             # extend surface to floor, and make wider since we have narrow field of view
@@ -163,7 +163,7 @@ class GraspingClient(object):
             self.scene.addSolidPrimitive(obj.name,
                                          obj.primitives[0],
                                          obj.primitive_poses[0],
-                                         use_service=True)
+                                         use_service=False)
 
         self.scene.waitForSync()
 

--- a/fetch_gazebo_demo/scripts/demo.py
+++ b/fetch_gazebo_demo/scripts/demo.py
@@ -149,7 +149,7 @@ class GraspingClient(object):
             self.scene.addSolidPrimitive(obj.object.name,
                                          obj.object.primitives[0],
                                          obj.object.primitive_poses[0],
-                                         False)
+                                         use_service=True)
 
         for obj in find_result.support_surfaces:
             # extend surface to floor, and make wider since we have narrow field of view
@@ -163,7 +163,7 @@ class GraspingClient(object):
             self.scene.addSolidPrimitive(obj.name,
                                          obj.primitives[0],
                                          obj.primitive_poses[0],
-                                         False)
+                                         use_service=True)
 
         self.scene.waitForSync()
 

--- a/fetch_gazebo_demo/scripts/demo.py
+++ b/fetch_gazebo_demo/scripts/demo.py
@@ -149,7 +149,7 @@ class GraspingClient(object):
             self.scene.addSolidPrimitive(obj.object.name,
                                          obj.object.primitives[0],
                                          obj.object.primitive_poses[0],
-                                         wait = False)
+                                         False)
 
         for obj in find_result.support_surfaces:
             # extend surface to floor, and make wider since we have narrow field of view
@@ -163,7 +163,7 @@ class GraspingClient(object):
             self.scene.addSolidPrimitive(obj.name,
                                          obj.primitives[0],
                                          obj.primitive_poses[0],
-                                         wait = False)
+                                         False)
 
         self.scene.waitForSync()
 


### PR DESCRIPTION
In this pull request, I made 3 changes to run demo.launch on melodic. (I followed [this tutorial](https://docs.fetchrobotics.com/gazebo.html))
1. Correct python runtime error.
2. Change inflation parameters for fetch navigation.
3. Fix fetch's amcl start pose in demo

Detailed descriptions are below. I am sorry for the long comment.

### 1. Correct python runtime error
Before moveit_python version 0.2.17, addSolidPrimitive function has `wait` key argument.
However, After version 0.3.0, wait key argument is replaced by `use_service` key argument.
This change causes runtime error on demo.py.
0.2.17 AddSolidPrimitive: https://github.com/mikeferguson/moveit_python/blob/0.2.17/src/moveit_python/planning_scene_interface.py#L207
0.3.0 AddSolidPrimitive: https://github.com/mikeferguson/moveit_python/blob/0.3.0/src/moveit_python/planning_scene_interface.py#L219

Now, 0.3.x is released on only kinetic or higher (not on indigo).
I think `wait` and `use_service` is a similar argument, so I change how to pass argument (wait = False -> False) so that we can use the same argument on indigo, kinetic and melodic.
If you have any other good ideas, please teach me.

### 2. Change inflation parameters for fetch navigation
By default inflation of move_base, fetch cannot come close to table and go through narrow door in demo.py. By reducing the value of inflation, these problems are solved. 
(param name: `/move_base/global(local)_costmap/inflater/inflation_radius`)

To compare the effect of parameter change, I captured screenshot of Rviz:
Problem in coming close to table: (Bad) Fig.1 (Good) Fig.2 
Problem in going through narrow door: (Bad) Fig.3 (Good) Fig.4 

I think inflation 0.3 is very small because fetch's inflation is also 0.3. Do you have any ideas to solve these problem?

Fig. 1 fetch cannot come close to the table with inflation 0.7 (default). In this case, fetch fails to grasp the blue box because IK is failed.
![inflation_0_7_table](https://user-images.githubusercontent.com/19769486/78146949-cd217280-746d-11ea-871c-82033a376e8c.png)

Fig. 2 fetch can come close to the table with inflation 0.3
![inflation_0_3_table](https://user-images.githubusercontent.com/19769486/78147140-0ce85a00-746e-11ea-9d2e-98f503911e5e.png)

Fig. 3 fetch cannot go through the narrow door even with inflation 0.4 (default is 0.7)
![inflation_0_4_door](https://user-images.githubusercontent.com/19769486/78147518-96982780-746e-11ea-8f95-e8ad3288fe27.png)

Fig. 4 fetch can go through the narrow door with inflation 0.3
![inflation_0_3_door](https://user-images.githubusercontent.com/19769486/78147541-a1eb5300-746e-11ea-8fb3-32245d3dc327.png)

### 3. Fix fetch's amcl start pose in demo
When I force-kill playground.launch and demo.launch, rosmaster is sometimes not killed and previous fetch's amcl pose is saved in the parameter server.
In such cases, when I launch playground.launch and demo.launch again, fetch's initial amcl pose is the same as the previous pose.
If fetch's initial amcl pose differs greatly from actual fetch pose, navigation is very likely to fail.
Therefore, I fixed fetch's amcl start pose.
(param name: `/amcl/initial_pose_x`, `/amcl/initial_pose_y` and `/amcl/initial_pose_a`)

I think this change is not needed if you assume rosmaster is always killed normally after using playground.launch and demo.launch.
