### PR TITLE
Fix test_zone map origin

### DIFF
--- a/fetch_gazebo_demo/maps/test_zone.yaml
+++ b/fetch_gazebo_demo/maps/test_zone.yaml
@@ -1,6 +1,6 @@
 image: test_zone.pgm
 resolution: 0.050000
-origin: [-10.929414, -10.830637, 0.000000]
+origin: [-10.50, -10.830637, 0.000000]
 negate: 0
 occupied_thresh: 0.65
 free_thresh: 0.196


### PR DESCRIPTION
Origin in the map didn't quite match origin in Gazebo. This is usually hidden by localization.

Screenshots show the robot spawned at 0,0. No localization is running (using ground truth from Gazebo instead) so the offset is visible and constant anywhere the robot goes.

Original map origin:
![Screenshot from 2020-05-15 15-31-55](https://user-images.githubusercontent.com/924295/82094005-d84cfc80-96c1-11ea-9210-8e8ff741ef83.png)
![Screenshot from 2020-05-15 15-32-10](https://user-images.githubusercontent.com/924295/82094019-dedb7400-96c1-11ea-955b-ba1a84b121e0.png)

Map origin fixed:
![Screenshot from 2020-05-15 15-30-23](https://user-images.githubusercontent.com/924295/82094068-f581cb00-96c1-11ea-8341-109a6d3a0f99.png)
![Screenshot from 2020-05-15 15-33-25](https://user-images.githubusercontent.com/924295/82094027-e438be80-96c1-11ea-8015-d1f4c64b1d0e.png)
