### PR TITLE
Add missing exec_depend directives

### DIFF
--- a/fetch_gazebo/package.xml
+++ b/fetch_gazebo/package.xml
@@ -38,4 +38,6 @@
   <exec_depend>rgbd_launch</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 </package>


### PR DESCRIPTION
FYI, you can check and find these sort of missing dependencies by using [roslaunch-check](http://wiki.ros.org/roslaunch/Commandline%20Tools)