### PR TITLE
Fixes noetic compatibility

### DIFF
--- a/fetch_gazebo/launch/include/fetch.launch.xml
+++ b/fetch_gazebo/launch/include/fetch.launch.xml
@@ -9,7 +9,7 @@
   <rosparam file="$(find fetch_gazebo)/config/default_controllers.yaml" command="load" />
 
   <!-- URDF and TF support -->
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find fetch_gazebo)/robots/fetch.gazebo.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find fetch_gazebo)/robots/fetch.gazebo.xacro" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
     <param name="publish_frequency" value="100.0"/>
   </node>

--- a/fetch_gazebo/launch/include/fetch_pp.launch.xml
+++ b/fetch_gazebo/launch/include/fetch_pp.launch.xml
@@ -9,7 +9,7 @@
   <rosparam file="$(find fetch_gazebo)/config/default_controllers.yaml" command="load" />
 
   <!-- URDF and TF support -->
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find fetch_gazebo)/robots/fetch.gazebo.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find fetch_gazebo)/robots/fetch.gazebo.xacro" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
     <param name="publish_frequency" value="100.0"/>
   </node>

--- a/fetch_gazebo/launch/include/freight.launch.xml
+++ b/fetch_gazebo/launch/include/freight.launch.xml
@@ -9,7 +9,7 @@
   <rosparam file="$(find fetch_gazebo)/config/freight_controllers.yaml" command="load" />
 
   <!-- URDF and TF support -->
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find fetch_gazebo)/robots/freight.gazebo.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find fetch_gazebo)/robots/freight.gazebo.xacro" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
     <param name="publish_frequency" value="100.0"/>
   </node>


### PR DESCRIPTION
This commit fixes a xacro.py not found bug that was thrown when trying out the package on ROS noetic. For more information see
https://wiki.ros.org/noetic/Migration. I am not sure if we can directly merge these changes on the gazebo9 branch or that we need to use a new gazebo9-noetic branch.